### PR TITLE
Improve vuetify usage

### DIFF
--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -12,7 +12,6 @@ declare module '@vue/runtime-core' {
     EventEditPage: typeof import('./components/pages/EventEditPage.vue')['default']
     EventPage: typeof import('./components/pages/EventPage.vue')['default']
     HomePage: typeof import('./components/pages/HomePage.vue')['default']
-    LoginModal: typeof import('./components/LoginModal.vue')['default']
     LoginPage: typeof import('./components/pages/LoginPage.vue')['default']
     Logo: typeof import('./components/Logo.vue')['default']
     NavBar: typeof import('./components/nav/NavBar.vue')['default']
@@ -20,7 +19,5 @@ declare module '@vue/runtime-core' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SideBar: typeof import('./components/nav/SideBar.vue')['default']
-    TheNavBar: typeof import('./components/nav/TheNavBar.vue')['default']
-    TheSideBar: typeof import('./components/nav/TheSideBar.vue')['default']
   }
 }

--- a/frontend/src/components/pages/LoginPage.vue
+++ b/frontend/src/components/pages/LoginPage.vue
@@ -1,52 +1,47 @@
 <template>
-  <div class="h-100 d-flex flex-column justify-space-between">
-    <main>
-      <!-- logo -->
-      <Logo class="mt-3"></Logo>
+  <v-container class="h-100 d-flex flex-column">
+    <!-- logo -->
+    <Logo class="mt-3"></Logo>
 
-      <!-- email field -->
-      <div class="mx-9 mt-13">
-        <p>No need for passwords.</p>
-        <p class="mb-8">Just enter your email below to register or log in.</p>
-        <v-form>
-          <v-text-field
-            filled
-            v-model="email"
-            name="Email"
-            label="Email"
-            placeholder="geniusPinapple@mail.com"
-            :rules="[(value) => !!value || 'Required']"
-          ></v-text-field>
-        </v-form>
-      </div>
-    </main>
+    <!-- email field -->
+    <div class="mx-9 mt-13">
+      <p>No need for passwords.</p>
+      <p class="mb-8">Just enter your email below to register or log in.</p>
+      <v-form>
+        <v-text-field
+          filled
+          v-model="email"
+          name="Email"
+          label="Email"
+          placeholder="geniusPinapple@mail.com"
+          :rules="[(value) => !!value || 'Required']"
+        ></v-text-field>
+      </v-form>
+    </div>
 
-    <footer class="mb-12">
-      <!-- button -->
-      <div class="d-flex">
-        <v-btn
-          class="mx-auto"
-          size="x-large"
-          color="primary"
-          variant="tonal"
-          append-icon="mdi-email"
-          rounded="pill"
-          type="submit"
-          :style="{ width: '65%' }"
-          :disabled="onSubmit.loading"
-          :loading="onSubmit.loading"
-          @click="onSubmit.handler"
-        >
-          <template v-slot:loader>
-            <v-progress-circular indeterminate />
-          </template>
-          <span class="text-h6">
-            {{ !mailSent ? "send" : "resend" }}
-          </span>
-        </v-btn>
-      </div>
-    </footer>
-  </div>
+    <div class="d-flex mb-12 mt-auto">
+      <v-btn
+        class="mx-auto"
+        size="x-large"
+        color="primary"
+        variant="tonal"
+        width="65%"
+        append-icon="mdi-email"
+        rounded
+        type="submit"
+        :disabled="onSubmit.loading"
+        :loading="onSubmit.loading"
+        @click="onSubmit.handler"
+      >
+        <template v-slot:loader>
+          <v-progress-circular indeterminate />
+        </template>
+        <span class="text-h6">
+          {{ !mailSent ? "send" : "resend" }}
+        </span>
+      </v-btn>
+    </div>
+  </v-container>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -32,8 +32,6 @@ const options: PluginOptions = {
  */
 import { createVuetify } from "vuetify";
 import "vuetify/styles";
-import * as components from "vuetify/components";
-import * as directives from "vuetify/directives";
 import "@mdi/font/css/materialdesignicons.css";
 import { aliases, mdi } from "vuetify/iconsets/mdi";
 // (see: https://github.com/vuetifyjs/vuetify/blob/next/packages/vuetify/src/locale/adapters/vue-i18n.ts)
@@ -43,8 +41,6 @@ import { aliases, mdi } from "vuetify/iconsets/mdi";
 // TODO: the imports above throw annoying errors although they should work in theory
 
 const vuetify = createVuetify({
-  components,
-  directives,
   theme: {
     defaultTheme: "light",
   },


### PR DESCRIPTION
Removed explicit declarations of vuetify components. They are auto-imported when needed and explicitly declaring them will import regardless of usage inflating the bundle size significantly.

Added vuetify components to the login page and fixed some semantic issues:
- multiple main elements
- footer element contained content which is part of the main content
