### PR TITLE
Add round logic to dashboard

### DIFF
--- a/frontend/src/components/TimeDisplay.vue
+++ b/frontend/src/components/TimeDisplay.vue
@@ -6,7 +6,10 @@
     :model-value="(modelValue / max) * 100"
   >
     <div class="d-flex flex-column align-center pt-4">
-      <span :class="'text-black d-block ' + textClass">{{ displayTime }}</span>
+      <v-progress-circular v-if="loading" indeterminate class="d-block" />
+      <span v-else :class="'text-black d-block ' + textClass">{{
+        displayTime
+      }}</span>
       <span class="text-grey d-block">min. left</span>
     </div>
   </v-progress-circular>
@@ -17,12 +20,19 @@ const props = withDefaults(
   defineProps<{
     modelValue: number;
     max: number;
+    loading?: boolean;
     size?: string;
     width?: string;
     color?: string;
     textClass?: string;
   }>(),
-  { size: "180", width: "12", color: "primary", textClass: "text-h4" }
+  {
+    loading: false,
+    size: "180",
+    width: "12",
+    color: "primary",
+    textClass: "text-h4",
+  }
 );
 
 const displayTime = computed(() => {

--- a/frontend/src/components/TimeDisplay.vue
+++ b/frontend/src/components/TimeDisplay.vue
@@ -18,12 +18,40 @@
 <script lang="ts" setup>
 const props = withDefaults(
   defineProps<{
+    /**
+     * The time to show in milliseconds.
+     * @model
+     */
     modelValue: number;
+    /**
+     * The maximum time that may be displayed in milliseconds.
+     * Used as a reference for progress.
+     */
     max: number;
+    /**
+     * Controls whether a loading state should be display.
+     * @defaultValue false
+     */
     loading?: boolean;
+    /**
+     * The size in pixels.
+     * @defaultValue "180"
+     */
     size?: string;
+    /**
+     * The width of the progress bar in pixels.
+     * @defaultValue "12"
+     */
     width?: string;
+    /**
+     * The color of the progress bar.
+     * @defaultValue "primary"
+     */
     color?: string;
+    /**
+     * Class string to use for the main text element.
+     * @defaultValue "text-h4"
+     */
     textClass?: string;
   }>(),
   {

--- a/frontend/src/components/TimeDisplay.vue
+++ b/frontend/src/components/TimeDisplay.vue
@@ -37,7 +37,7 @@ const props = withDefaults(
 
 const displayTime = computed(() => {
   const minutes = Math.floor(props.modelValue / (60 * 1000));
-  const seconds = Math.ceil((props.modelValue % (60 * 1000)) / 1000);
+  const seconds = Math.floor((props.modelValue % (60 * 1000)) / 1000);
   return (
     String(minutes).padStart(2, "0") + ":" + String(seconds).padStart(2, "0")
   );

--- a/frontend/src/components/pages/EventDashboard.vue
+++ b/frontend/src/components/pages/EventDashboard.vue
@@ -4,7 +4,11 @@
       <div class="bg-grey mb-6" :style="{ height: '100px' }"></div>
       <div class="text-h6 mb-2">{{ t("pages.dashboard.ongoing.round") }} 1</div>
       <div class="d-flex justify-center mb-4">
-        <time-display :model-value="time" :max="timeSaved" />
+        <time-display
+          :loading="startingRound"
+          :model-value="time"
+          :max="actualDuration"
+        />
       </div>
       <v-slider
         v-model="timeInput"
@@ -25,9 +29,12 @@
 </template>
 
 <script lang="ts" setup>
+import { useCurrentEventStore } from "@/stores/currentEvent";
+import { Temporal } from "@js-temporal/polyfill";
 import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
+const currentEvent = useCurrentEventStore();
 
 const second = 1000;
 const minute = 60 * second;
@@ -35,29 +42,43 @@ const hour = 60 * minute;
 const time = ref(minute);
 
 const roundOngoing = ref(false);
+const startingRound = ref(false);
 const countingInterval = ref<ReturnType<typeof setInterval>>();
 
-const timeSaved = ref(minute);
+const setDuration = ref(minute);
+const actualDuration = ref(minute);
+
 const timeInput = computed<number>({
   get() {
-    return timeSaved.value;
+    return setDuration.value;
   },
   set(newVal) {
+    setDuration.value = newVal;
     time.value = newVal;
-    timeSaved.value = newVal;
   },
 });
 
-const startRound = () => {
+const startRound = async () => {
   roundOngoing.value = true;
   // make sure there's only ever 1 interval at a time
   clearInterval(countingInterval.value);
+  startingRound.value = true;
+  const round = await currentEvent.startNewRound(setDuration.value);
+  const start = Temporal.Now.zonedDateTimeISO();
+  const end = Temporal.Instant.from(round.end_timestamp).toZonedDateTimeISO(
+    Temporal.Now.timeZone()
+  );
+  const diff = end.since(start);
+  actualDuration.value = diff.total({ unit: "milliseconds" });
+  time.value = actualDuration.value;
   countingInterval.value = setInterval(() => {
     time.value = Math.max(time.value - 1000, 0);
     if (time.value === 0) {
       roundOngoing.value = false;
       clearInterval(countingInterval.value);
+      time.value = setDuration.value;
     }
   }, 1000);
+  startingRound.value = false;
 };
 </script>

--- a/frontend/src/stores/currentEvent.ts
+++ b/frontend/src/stores/currentEvent.ts
@@ -47,7 +47,34 @@ export const useCurrentEventStore = defineStore("current-event", () => {
     return data[0];
   }
 
-  return { hasEvent, getCurrentId, setCurrentId, startEvent, startNewRound };
+  /**
+   * Gets the current event's ongoing round if it exists else null
+   *
+   * @returns The current ongoing round or null
+   */
+  async function getCurrentRound(): Promise<
+    definitions["event_rounds"] | null
+  > {
+    if (!currentEventId.value) throw new Error("There is no current event.");
+    const now = Temporal.Now.zonedDateTimeISO(Temporal.Now.timeZone());
+    const { data, error } = await supabase
+      .from("event_rounds")
+      .select("*")
+      .gte("end_timestamp", now.toInstant().toString())
+      .limit(1)
+      .maybeSingle();
+    if (error) throw error;
+    return data;
+  }
+
+  return {
+    hasEvent,
+    getCurrentId,
+    setCurrentId,
+    startEvent,
+    startNewRound,
+    getCurrentRound,
+  };
 });
 
 if (import.meta.hot) {

--- a/frontend/src/stores/currentEvent.ts
+++ b/frontend/src/stores/currentEvent.ts
@@ -1,6 +1,8 @@
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { useStorage } from "@vueuse/core";
 import { supabase } from "@/services/supabase";
+import { Temporal } from "@js-temporal/polyfill";
+import type { definitions } from "@/services/supabase-types";
 
 export const useCurrentEventStore = defineStore("current-event", () => {
   const currentEventId = useStorage("current-event-id", "");
@@ -26,7 +28,26 @@ export const useCurrentEventStore = defineStore("current-event", () => {
     setCurrentId(id);
   }
 
-  return { hasEvent, getCurrentId, setCurrentId, startEvent };
+  async function startNewRound(
+    duration: number
+  ): Promise<definitions["event_rounds"]> {
+    if (!currentEventId.value) throw new Error("There is no current event.");
+    const now = Temporal.Now.zonedDateTimeISO(Temporal.Now.timeZone());
+    const endTime = now.add({ milliseconds: duration });
+    const { error, data } = await supabase.from("event_rounds").insert(
+      {
+        event_id: +currentEventId.value,
+        start_timestamp: now.toInstant().toString(),
+        end_timestamp: endTime.toInstant().toString(),
+      },
+      { returning: "representation" }
+    );
+    if (error) throw error;
+    if (!data) throw new Error("Inserted event round was not returned");
+    return data[0];
+  }
+
+  return { hasEvent, getCurrentId, setCurrentId, startEvent, startNewRound };
 });
 
 if (import.meta.hot) {


### PR DESCRIPTION
Adds:
- Loading state to time-display component
- Some docs for time-display component
- Logic to start new rounds to store
- Display and countdown round time
- Fetching ongoing round in case the user navigated off the route